### PR TITLE
Allow specifying path to source and test namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml
 *#
 .#*
 */.lein-repl-history
+*/out/
+.nrepl-port


### PR DESCRIPTION
**Overview**
Added a feature that allows users specify path to source and test namespaces
when calling cloverage. This is an alternative to using regexs for people who
keep all their source code under one directory (e.g. src) and all their tests
under a different one (e.g. test).

**Example Use**
--src-ns-path "PATH_TO_DIRECTORY_WITH_SOURCE_NAMESPACES"
--test-ns-path "PATH_TO_DIRECTORY_WITH_TEST_NAMESPACES"