### PR TITLE
Cloverage fails to instrument records

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -217,12 +217,20 @@
 (defmethod do-wrap :atomic [f line form _]
   (f line form))
 
+;; Only here for Clojure 1.4 compatibility, 1.6 has record?
+(defn- map-record? [x]
+  (instance? clojure.lang.IRecord x))
+
 ;; For a collection, just recur on its elements.
 (defmethod do-wrap :coll [f line form _]
   (tprn ":coll" form)
   (let [wrappee (map (wrapper f line) form)
         wrapped (cond (vector? form) `[~@wrappee]
                       (set? form) `#{~@wrappee}
+                      (map-record? form) (merge form
+                                           (zipmap
+                                             (keys form)
+                                             (doall (map (wrapper f line) (vals form)))))
                       (map? form) (zipmap
                                    (doall (map (wrapper f line) (keys form)))
                                    (doall (map (wrapper f line) (vals form))))

--- a/cloverage/test/cloverage/test_instrument.clj
+++ b/cloverage/test/cloverage/test_instrument.clj
@@ -28,6 +28,13 @@
   ([f] (form-type- f nil))
   ([f e] (form-type f e)))
 
+(defprotocol Protocol
+  (method [this]))
+
+(defrecord Record [foo]
+  Protocol
+  (method [_] foo))
+
 (deftest test-form-type
   (is (= :atomic (form-type- 1)))
   (is (= :atomic (form-type- "foo")))
@@ -35,11 +42,15 @@
   (is (= :coll (form-type- [1 2 3 4])))
   (is (= :coll (form-type- {1 2 3 4})))
   (is (= :coll (form-type- #{1 2 3 4})))
+  (is (= :coll (form-type- (Record. 1))))
   (is (= :list (form-type- '(+ 1 2))))
   (is (= :do (form-type- '(do 1 2 3))))
   (is (= :list (form-type- '(loop 1 2 3)
                           {'loop 'hoop} ;fake a local binding
                           ))))
+
+(deftest do-wrap-for-record-returns-record
+  (is (= 1 (eval (method (eval (wrap #'nop 0 (Record. 1))))))))
 
 (deftest preserves-fn-conditions
   (let [pre-fn (eval (wrap #'nop 0


### PR DESCRIPTION
See the test case in https://github.com/jvah/compojure-cloverage-crash.

If I run lein test everything passes but lein cloverage crashes, so I'm suspecting this might actually be a bug in how cloverage instruments the code. Had a small discussion about this at compojure issue https://github.com/weavejester/compojure/issues/135 which you might want to look at. Any pointers on how to fix this would be welcome.