### PR TITLE
Don't get an ArithmeticException if there's no test coverage

### DIFF
--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -216,9 +216,10 @@
         partial    (total :partial-lines)
         lines      (total :instrd-lines)
         cov-forms  (total :covered-forms)
-        forms      (total :forms)]
-    {:percent-lines-covered (* (/ (+ covered partial) lines) 100.0)
-     :percent-forms-covered (* (/ cov-forms forms) 100.0)}))
+        forms      (total :forms)
+        line-total (+ covered partial)]
+    {:percent-lines-covered (if (= line-total 0) 0. (* (/ line-total lines) 100.0))
+     :percent-forms-covered (if (= cov-forms 0) 0. (* (/ cov-forms forms) 100.0))}))
 
 (defn html-summary [out-dir forms]
   (let [index (File. out-dir "index.html")

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -218,8 +218,8 @@
         cov-forms  (total :covered-forms)
         forms      (total :forms)
         line-total (+ covered partial)]
-    {:percent-lines-covered (if (= line-total 0) 0. (* (/ line-total lines) 100.0))
-     :percent-forms-covered (if (= cov-forms 0) 0. (* (/ cov-forms forms) 100.0))}))
+    {:percent-lines-covered (if (= lines 0) 0. (* (/ line-total lines) 100.0))
+     :percent-forms-covered (if (= lines 0) 0. (* (/ cov-forms forms) 100.0))}))
 
 (defn html-summary [out-dir forms]
   (let [index (File. out-dir "index.html")

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -216,9 +216,8 @@
         partial    (total :partial-lines)
         lines      (total :instrd-lines)
         cov-forms  (total :covered-forms)
-        forms      (total :forms)
-        line-total (+ covered partial)]
-    {:percent-lines-covered (if (= lines 0) 0. (* (/ line-total lines) 100.0))
+        forms      (total :forms)]
+    {:percent-lines-covered (if (= lines 0) 0. (* (/ (+ covered partial) lines) 100.0))
      :percent-forms-covered (if (= forms 0) 0. (* (/ cov-forms forms) 100.0))}))
 
 (defn html-summary [out-dir forms]

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -219,7 +219,7 @@
         forms      (total :forms)
         line-total (+ covered partial)]
     {:percent-lines-covered (if (= lines 0) 0. (* (/ line-total lines) 100.0))
-     :percent-forms-covered (if (= lines 0) 0. (* (/ cov-forms forms) 100.0))}))
+     :percent-forms-covered (if (= forms 0) 0. (* (/ cov-forms forms) 100.0))}))
 
 (defn html-summary [out-dir forms]
   (let [index (File. out-dir "index.html")

--- a/cloverage/test/cloverage/test_report.clj
+++ b/cloverage/test/cloverage/test_report.clj
@@ -14,3 +14,6 @@
   (is (= "dir/" (relative-path (File. "/tmp/dir/") (File. "/tmp"))))
   (is (= "" (relative-path (File. "/") (File. "/"))))
   (is (= "" (relative-path (File. "dir/file/") (File. "dir/file/")))))
+
+(deftest total-stats-zero
+  (is (= {:percent-lines-covered 0.0, :percent-forms-covered 0.0} (total-stats {}))))


### PR DESCRIPTION
Previously, if the code coverage was 0, the reporting code would throw an ArithmeticException with divide-by-zero.