### PR TITLE
Automatically push out SNAPSHOT builds after successful `master` build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ jdk:
   - oraclejdk7
   - openjdk7
   - openjdk6
+
+after_success:
+  - (cd cloverage && lein2 deploy clojars)
+  - (cd lein-cloverage && lein2 deploy clojars)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ jdk:
   - openjdk6
 
 after_success:
-  - (cd cloverage && lein2 deploy clojars)
-  - (cd lein-cloverage && lein2 deploy clojars)
+  - bash deploy.sh

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ IllegalArgumentException No matching field found: foo for class user.Bar  clojur
 
 Since cloverage *will* wrap the -foo symbol to track whether it's accessed, you will get this error. Upgrade to clojure 1.6.
 
+## Releases
 
+In order to release to Clojars, you'll need to set `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` in your environment variables.
 
 ## Changelog
 1.0.5:
@@ -82,6 +84,7 @@ Distributed under the Eclipse Public License, the same as Clojure.
 
 ### Contributors
 
+* 2015 LShift, Tom Parker
 * 2012 LShift, Jacek Lach, Alexander Schmolck, Frank Shearar
 * 2010 Michael Delaurentis
 

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -10,6 +10,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
+  :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password}]]
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/tools.cli "0.2.2"]
                  [org.clojure/tools.logging "0.2.3"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-if [ x${TRAVIS_BRANCH} == x${DEPLOY_BRANCH} ]; then
-  echo "On branch '$TRAVIS_BRANCH' which is the deployment branch so deploying"
+if [ x${TRAVIS_PULL_REQUEST} == xfalse ]; then
+  echo "Not a pull request, so deploying"
   (cd cloverage && lein deploy clojars)
   (cd lein-cloverage && lein deploy clojars)
 else
-  echo "On branch '$TRAVIS_BRANCH' which isn't the deployment branch ($DEPLOY_BRANCH) so not doing a deploy"
+  echo "Building a pull request, so not deploying"
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ x${TRAVIS_BRANCH} == x${DEPLOY_BRANCH} ]; then
+  echo "On branch '$TRAVIS_BRANCH' which is the deployment branch so deploying"
+  (cd cloverage && lein deploy clojars)
+  (cd lein-cloverage && lein deploy clojars)
+else
+  echo "On branch '$TRAVIS_BRANCH' which isn't the deployment branch ($DEPLOY_BRANCH) so not doing a deploy"
+fi

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -9,6 +9,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
+  :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password}]]
   :min-lein-version "2.0.0"
   :dependencies [[bultitude "0.2.0"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
This deprecates #18, making it so we set various environment variables in Travis (CLOJARS_USERNAME, CLOJARS_PASSWORD) to deal with authentication and only deploying on the right branch