### PR TITLE
Update key used for obtaining regexs for test namespaces

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -130,7 +130,7 @@
         help?         (:help opts)
         add-test-nses (:extra-test-ns opts)
         ns-regexs     (map re-pattern (:ns-regex opts))
-        test-regexs   (map re-pattern (:test-ns-regexp opts))
+        test-regexs   (map re-pattern (:test-ns-regex opts))
         start         (System/currentTimeMillis)
         test-nses     (concat add-test-nses (find-nses test-regexs))
         namespaces    (concat add-nses      (find-nses ns-regexs))


### PR DESCRIPTION
Incorrect key was being used for obtaining regular expressions to matach test
namespaces.

"test-ns-regexp" was being used instead of "test-ns-regex"