### PR TITLE
Add */out/ and */.nrepl-port to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml
 *#
 .#*
 */.lein-repl-history
+*/out/
+*/.nrepl-port


### PR DESCRIPTION
These files were being unnecessarily tracked by git. Adding to .gitignore to
prevent people from accidentally committing them.