### PR TITLE
Allow specifying path to source and test namespaces

### DIFF
--- a/cloverage/test/cloverage/sample/dummy_sample.clj
+++ b/cloverage/test/cloverage/sample/dummy_sample.clj
@@ -1,0 +1,7 @@
+(ns cloverage.sample.dummy-sample
+  "This namespace is necessary for redundancy.
+  It allows us to check whether regexs in combination with path parameters work.")
+
+(defn dummy-function
+  [& args]
+  (println "Hello, World!"))


### PR DESCRIPTION
**Overview**
Added a feature that allows users specify path to source and test namespaces
when calling cloverage. This is an alternative to using regexs for people who
keep all their source code under one directory (e.g. src) and all their tests
under a different one (e.g. test).

**Example Use**
--src-ns-path "PATH_TO_DIRECTORY_WITH_SOURCE_NAMESPACES"
--test-ns-path "PATH_TO_DIRECTORY_WITH_TEST_NAMESPACES"