### PR TITLE
Enable test regex via lein plugin

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -103,11 +103,11 @@
         "Regex for test namespaces (can be repeated)."
         :default []
         :parse-fn (collecting-args-parser)]
-       ["-p" "--src-ns-paths"
+       ["-p" "--src-ns-path"
         "Path (string) to directory containing source code namespaces (can be repeated)."
         :default  []
         :parse-fn (collecting-args-parser)]
-       ["-s" "--test-ns-paths"
+       ["-s" "--test-ns-path"
         "Path (string) to directory containing test namespaces (can be repeated)."
         :default  []
         :parse-fn (collecting-args-parser)]
@@ -156,8 +156,8 @@
         ns-regexs     (map re-pattern (:ns-regex opts))
         test-regexs   (map re-pattern (:test-ns-regex opts))
         exclude-regex (map re-pattern (:ns-exclude-regex opts))
-        ns-paths      (:src-ns-paths opts)
-        test-ns-paths (:test-ns-paths opts)
+        ns-paths      (:src-ns-path opts)
+        test-ns-paths (:test-ns-path opts)
         start         (System/currentTimeMillis)
         namespaces    (set/difference
                         (into #{}

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -103,12 +103,14 @@
         "Regex for test namespaces (can be repeated)."
         :default []
         :parse-fn (collecting-args-parser)]
-       ["-p" "--src-ns-path"
-        "Path (string) to directory containing source code namespaces."
-        :default nil]
-       ["-s" "--test-ns-path"
-        "Path (string) to directory containing test namespaces."
-        :default nil]
+       ["-p" "--src-ns-paths"
+        "Path (string) to directory containing source code namespaces (can be repeated)."
+        :default  []
+        :parse-fn (collecting-args-parser)]
+       ["-s" "--test-ns-paths"
+        "Path (string) to directory containing test namespaces (can be repeated)."
+        :default  []
+        :parse-fn (collecting-args-parser)]
        ["-x" "--extra-test-ns"
         "Additional test namespace (string) to add (can be repeated)."
         :default  []
@@ -119,16 +121,17 @@
   (binding [*ns* (find-ns 'clojure.core)]
     (eval `(dosync (alter clojure.core/*loaded-libs* conj '~namespace)))))
 
-(defn find-nses [ns-path regex-patterns]
-  "Given ns-path and regex-patterns returns:
-  * empty sequence when ns-path is nil and regex-patterns is empty
-  * all namespaces on ns-path (if regex-patterns is empty)
-  * all namespaces on the classpath that match any of the regex-patterns (if ns-path is nil)
-  * namespaces on ns-path that match any of the regex-patterns"
+(defn find-nses
+  "Given ns-paths and regex-patterns returns:
+  * empty sequence when ns-paths is empty and regex-patterns is empty
+  * all namespaces on ns-paths (if regex-patterns is empty)
+  * all namespaces on the classpath that match any of the regex-patterns (if ns-paths is empty)
+  * namespaces on ns-paths that match any of the regex-patterns"
+  [ns-paths regex-patterns]
   (let [namespaces (->> (cond
-                         (and (nil? ns-path) (empty? regex-patterns)) '()
-                         (nil? ns-path) (blt/namespaces-on-classpath)
-                         :else (blt/namespaces-on-classpath :classpath ns-path))
+                         (and (empty? ns-paths) (empty? regex-patterns)) '()
+                         (empty? ns-paths) (blt/namespaces-on-classpath)
+                         :else (mapcat blt/namespaces-in-dir ns-paths))
                         (map name))]
     (if (seq regex-patterns)
       (filter (fn [namespace] (some #(re-matches % namespace) regex-patterns))
@@ -153,15 +156,15 @@
         ns-regexs     (map re-pattern (:ns-regex opts))
         test-regexs   (map re-pattern (:test-ns-regex opts))
         exclude-regex (map re-pattern (:ns-exclude-regex opts))
-        ns-path       (:src-ns-path opts)
-        test-ns-path  (:test-ns-path opts)
+        ns-paths      (:src-ns-paths opts)
+        test-ns-paths (:test-ns-paths opts)
         start         (System/currentTimeMillis)
         namespaces    (set/difference
                         (into #{}
                               (concat add-nses
-                                      (find-nses ns-path ns-regexs)))
-                        (into #{} (find-nses ns-path exclude-regex)))
-        test-nses     (concat add-test-nses (find-nses test-ns-path test-regexs))]
+                                      (find-nses ns-paths ns-regexs)))
+                        (into #{} (find-nses ns-paths exclude-regex)))
+        test-nses     (concat add-test-nses (find-nses test-ns-paths test-regexs))]
     (if help?
       (println help)
       (binding [*ns*      (find-ns 'cloverage.coverage)

--- a/cloverage/test/cloverage/sample/dummy/sample.clj
+++ b/cloverage/test/cloverage/sample/dummy/sample.clj
@@ -1,4 +1,4 @@
-(ns cloverage.sample.dummy-sample
+(ns cloverage.sample.dummy.sample
   "This namespace is necessary for redundancy.
   It allows us to check whether regexs in combination with path parameters work.")
 

--- a/cloverage/test/cloverage/sample/read_eval/sample.clj
+++ b/cloverage/test/cloverage/sample/read_eval/sample.clj
@@ -1,4 +1,4 @@
-(ns cloverage.sample.read-eval-sample)
+(ns cloverage.sample.read-eval.sample)
 
 (def ^:dynamic *dynamic-var*)
 

--- a/cloverage/test/cloverage/test_coverage.clj
+++ b/cloverage/test/cloverage/test_coverage.clj
@@ -199,26 +199,32 @@
 
 (deftest test-find-nses
   (testing "empty sequence is returned when neither paths nor regexs are provided"
-    (is (empty? (find-nses nil []))))
-  (testing "all namespaces in a directory get returned when only path is provided"
-    (is (compare-colls (find-nses "test/cloverage/sample" [])
-                       ["cloverage.sample.dummy-sample"
-                        "cloverage.sample.read-eval-sample"])))
+    (is (empty? (find-nses [] []))))
+  (testing "all namespaces in the provided directories get returned"
+    (testing "when one path is provided"
+      (is (compare-colls (find-nses ["test/cloverage/sample"] [])
+                         ["cloverage.sample.dummy.sample"
+                          "cloverage.sample.read-eval.sample"])))
+    (testing "when multiple paths are provided"
+      (is (compare-colls (find-nses ["test/cloverage/sample/read_eval"
+                                     "test/cloverage/sample/dummy"] [])
+                         ["cloverage.sample.dummy.sample"
+                          "cloverage.sample.read-eval.sample"]))))
   (testing "only matching namespaces (from classpath) are returned when only
            regex patterns are provided:"
     (testing "single pattern case"
-      (is (= (find-nses nil [#"^cloverage\.sample\.read.*$"])
-             ["cloverage.sample.read-eval-sample"])))
+      (is (= (find-nses [] [#"^cloverage\.sample\.read.*$"])
+             ["cloverage.sample.read-eval.sample"])))
     (testing "multiple patterns case"
-      (is (compare-colls (find-nses nil [#"^cloverage\.sample\.read.*$"
-                                         #"^cloverage\..*coverage$"])
-                         ["cloverage.sample.read-eval-sample"
+      (is (compare-colls (find-nses [] [#"^cloverage\.sample\.read.*$"
+                                        #"^cloverage\..*coverage$"])
+                         ["cloverage.sample.read-eval.sample"
                           "cloverage.test-coverage"
                           "cloverage.coverage"]))))
   (testing "only matching namespaces from a directory are returned when both path
            and patterns are provided"
-    (is (= (find-nses "test/cloverage/sample" [#".*dummy.*"])
-           ["cloverage.sample.dummy-sample"]))))
+    (is (= (find-nses ["test/cloverage/sample"] [#".*dummy.*"])
+           ["cloverage.sample.dummy.sample"]))))
 
 (deftest test-main
   (binding [cloverage.coverage/*exit-after-test* false]

--- a/cloverage/test/cloverage/test_coverage.clj
+++ b/cloverage/test/cloverage/test_coverage.clj
@@ -226,6 +226,28 @@
     (is (= (find-nses ["test/cloverage/sample"] [#".*dummy.*"])
            ["cloverage.sample.dummy.sample"]))))
 
+(deftest test-flags
+  (binding [cloverage.coverage/*exit-after-test* false]
+    (let [main (fn [& args]
+                 (binding [*out* (new java.io.StringWriter)]
+                   (apply cloverage.coverage/-main args)))]
+      (testing "test paths can be filtered with --test-ns-regex"
+        (is (=
+             (main
+              "--no-html" "--nop"
+              "-s" "test/cloverage/sample"
+              "-t" "ns.that.does.not.exist"
+              "cloverage.sample")
+            -1)))
+      (testing "--extra-test-ns will not get filtered by --test-ns-regex"
+        (is (=
+             (main
+              "--no-html" "--nop"
+              "-x" "cloverage.sample"
+              "-t" "ns.that.does.not.exist"
+              "cloverage.sample")
+            0))))))
+
 (deftest test-main
   (binding [cloverage.coverage/*exit-after-test* false]
     (is (=

--- a/cloverage/test/cloverage/test_instrument.clj
+++ b/cloverage/test/cloverage/test_instrument.clj
@@ -21,7 +21,7 @@
 
 (deftest correctly-resolves-macro-symbols
   ;; simply ensure that instrumentation succeeds without errors
-  (is (instrument #'no-instr 'cloverage.sample.read-eval-sample)))
+  (is (instrument #'no-instr 'cloverage.sample.read-eval.sample)))
 
 (defn- form-type-
   "Provide a default empty env to form-type, purely for easier testing."

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -16,5 +16,4 @@
   }
   :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :min-lein-version "2.0.0"
-  :dependencies [[bultitude "0.2.0"]]
   :eval-in-leiningen true)

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -1,9 +1,5 @@
 (ns leiningen.cloverage
-  (:require [leiningen.run :as run]
-            [bultitude.core :as blt]))
-
-(defn ns-names-for-dirs [dirs]
-  (map name (mapcat blt/namespaces-in-dir dirs)))
+  (:require [leiningen.run :as run]))
 
 (defn get-lib-version []
   (or (System/getenv "CLOVERAGE_VERSION") "RELEASE"))
@@ -14,11 +10,10 @@
   To specify cloverage version, set the CLOVERAGE_VERSION environment variable.
   Specify -o OUTPUTDIR for output directory, for other options see cloverage."
   [project & args]
-  (let [source-namespaces (ns-names-for-dirs (:source-paths project))
-        test-namespace    (ns-names-for-dirs (:test-paths project))]
+  (let [coll-to-args (fn [flag coll] (mapcat #(list flag %) coll))
+        source-paths (coll-to-args "-p" (:source-paths project))
+        test-paths   (coll-to-args "-s" (:test-paths project))]
     (apply run/run (update-in project [:dependencies]
                               conj    ['cloverage (get-lib-version)])
            "-m" "cloverage.coverage"
-           (concat (mapcat  #(list "-x" %) test-namespace)
-                   args
-                   source-namespaces))))
+           (concat source-paths test-paths args))))

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -4,14 +4,16 @@
 (defn get-lib-version []
   (or (System/getenv "CLOVERAGE_VERSION") "RELEASE"))
 
+(defn coll-to-args [flag coll]
+  (mapcat #(list flag %) coll))
+
 (defn cloverage
   "Run code coverage on the project.
 
   To specify cloverage version, set the CLOVERAGE_VERSION environment variable.
   Specify -o OUTPUTDIR for output directory, for other options see cloverage."
   [project & args]
-  (let [coll-to-args (fn [flag coll] (mapcat #(list flag %) coll))
-        source-paths (coll-to-args "-p" (:source-paths project))
+  (let [source-paths (coll-to-args "-p" (:source-paths project))
         test-paths   (coll-to-args "-s" (:test-paths project))]
     (apply run/run (update-in project [:dependencies]
                               conj    ['cloverage (get-lib-version)])


### PR DESCRIPTION
Currently, `-t` does not work via lein plugin because cloverage does not
modify namespace selection if namespaces are provided via the `-x` flag
(which is how the lein plugin provides project test paths to cloverage).

This proposed fix modifies cloverage to support multiple ns-paths for src and test
(via `-s` and `-p` flags), and then changes the lein plugin to use those flags instead of the
explicit add-ns options.

An example of behavior, before and after:

```
# project with test/myapp/v1.clj & test/myapp/v2.clj
lein cloverage -t ".*v1" # previously tested both myapp.v1 & myapp.v2
lein cloverage -t ".*v1" # now only tests myapp.v1
```