### PR TITLE
Codecov support

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -26,7 +26,9 @@
 (defn cover [idx]
   "Mark the given file and line in as having been covered."
   (if (contains? @*covered* idx)
-    (swap! *covered* assoc-in [idx :covered] true)
+    (swap! *covered* #(-> %
+                          (assoc-in [idx :covered] true)
+                          (update-in [idx :hits] (fnil inc 1))))
     (log/warn (str "Couldn't track coverage for form with index " idx
                    " covered has " (count @*covered*) "."))))
 

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -84,6 +84,8 @@
         "Produce an HTML report." :default true]
        ["--[no-]emma-xml"
         "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
+       ["--[no-]codecov"
+        "Generate a JSON report for Codecov.io" :default false]
        ["--[no-]coveralls"
         "Send a JSON report to Coveralls if on a CI server" :default false]
        ["--[no-]raw"
@@ -146,6 +148,7 @@
         html?         (:html opts)
         raw?          (:raw opts)
         emma-xml?     (:emma-xml opts)
+        codecov?      (:codecov opts)
         coveralls?    (:coveralls opts)
         summary?      (:summary opts)
         debug?        (:debug opts)
@@ -199,6 +202,7 @@
                              (html-summary output stats))
                            (when emma-xml? (emma-xml-report output stats))
                            (when raw? (raw-report output stats @*covered*))
+                           (when codecov? (codecov-report output stats))
                            (when coveralls? (coveralls-report output stats))
                            (when summary? (summary stats))]]
 

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -323,6 +323,32 @@
                                           :service_name service
                                           :source_files covdata}))))))
 
+
+(defn codecov-report [out-dir forms]
+  (println "codecov start")
+  (let [data (filter (fn [[file _]] file) (group-by :file forms))
+        covdata
+        (into {}
+              (map
+               (fn [[file file-forms]]
+                 ;; https://codecov.io/api#post-json-report
+                 ;; > 0: covered (number of times hit)
+                 ;; true: partially covered
+                 ;; 0: not covered
+                 ;; null: skipped/ignored/empty
+                 ;; the first item in the list must be a null
+                 (vector file
+                         (cons nil
+                               (mapv (fn [line]
+                                       (cond (:blank?   line) nil
+                                             (:covered? line) (:times-hit line)
+                                             (:partial? line) true
+                                             (:instrumented? line) 0
+                                             :else nil)) (line-stats file-forms)))))
+               data))]
+    (with-out-writer (File. out-dir "codecov.json")
+      (print (json/generate-string {:coverage covdata})))))
+
 (defn raw-report [out-dir stats covered]
   (with-out-writer (File. (File. out-dir) "raw-data.clj")
     (clojure.pprint/pprint (zipmap (range) covered)))

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -41,11 +41,16 @@
 (defn line-stats [forms]
   (for [[line line-forms] (group-by-line forms)]
     (let [total (count (filter :tracked line-forms))
-          hit   (count (filter :covered line-forms))]
+          hit   (count (filter :covered line-forms))
+          times-hit (if (zero? hit)
+                      hit
+                      (apply max (filter number?
+                                         (map :hits line-forms))))]
       {:line     line
        :text     (:text (first line-forms))
        :total    total
        :hit      hit
+       :times-hit times-hit
        :blank?   (empty? (:text (first line-forms)))
        :covered? (and (> total 0) (= total hit))
        :partial? (and (> hit 0) (< hit total))


### PR DESCRIPTION
Generate codecov.io compatible reports.

Submitting reports is simple:

    $ lein cloverage --codecov
    $ bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
