### PR TITLE
Use indexing push-back reader from clojure.tools.reader

### DIFF
--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -16,7 +16,8 @@
     :scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
     :deploy-via :clojars
   }
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/tools.reader "0.9.2"]
                  [org.clojure/tools.cli "0.2.2"]
                  [org.clojure/tools.logging "0.2.3"]
                  [org.clojure/data.xml "0.0.7"]

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -17,7 +17,7 @@
     :scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
     :deploy-via :clojars
   }
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/tools.reader "0.9.2"]
                  [org.clojure/tools.cli "0.3.1"]
                  [org.clojure/tools.logging "0.3.1"]

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -18,10 +18,10 @@
   }
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.reader "0.9.2"]
-                 [org.clojure/tools.cli "0.2.2"]
-                 [org.clojure/tools.logging "0.2.3"]
-                 [org.clojure/data.xml "0.0.7"]
-                 [bultitude "0.2.0"]
-                 [riddley "0.1.4"]
-                 [slingshot "0.10.3"]
-                 [cheshire "5.3.1"]])
+                 [org.clojure/tools.cli "0.3.1"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/data.xml "0.0.8"]
+                 [bultitude "0.2.7"]
+                 [riddley "0.1.10"]
+                 [slingshot "0.12.2"]
+                 [cheshire "5.5.0"]])

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -6,6 +6,7 @@
         :url  "https://www.github.com/lshift/cloverage"
         :tag  "HEAD"}
   :main ^:skip-aot cloverage.coverage
+  :aot [clojure.tools.reader]
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo


### PR DESCRIPTION
Switch over to the indexing push-back reader from tools.reader as it
adds column information to metadata and adds line metadata to lots of
things that the builtin `LineNumberingPushbackReader` misses.

The indexing reader makes reports more accurate and fixes an issue where
if a long form is broken up over multiple lines, some of the lines may
be reported as ignored.


Regarding the AOT compilation of clojure.tools.reader:
Older versions of clojure.tools.reader increase all line numbers by one.
This results in odd looking reports where you have comments or blank
lines showing as missing test coverage or weirder still as being covered
if you have one of these older versions of clojure.tools.reader being
pulled in transitively by another dependency.

AOT compilation of tools.reader is necessary because configuring
:exclusions for tools.reader on those dependencies which pull in the old
version is ineffective when that dependency is using AOT (case in point:
riemann). Unfortunately leiningen isn't doing the smart thing of using
the newer but uncompiled version of a dependency yet. The only work
around is fragile and untenable with a CI service. See the following
github issues for more info:

https://github.com/technomancy/leiningen/issues/1879
https://github.com/technomancy/leiningen/issues/1858
