### PR TITLE
Migrate to new Travis containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ lein: lein2
 install: (cd cloverage && lein2 deps) && (cd lein-cloverage && lein2 deps)
 script: (cd cloverage && lein2 test) && (cd lein-cloverage && lein2 test)
 sudo: false
+cache:
+  directories:
+    - $HOME/.m2
 
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: clojure
 lein: lein2
 install: (cd cloverage && lein2 deps) && (cd lein-cloverage && lein2 deps)
 script: (cd cloverage && lein2 test) && (cd lein-cloverage && lein2 test)
+sudo: false
 
 jdk:
   - oraclejdk7


### PR DESCRIPTION
Because they're faster and we can cache the JARs

http://docs.travis-ci.com/user/migrating-from-legacy/