### PR TITLE
Optimise cover fn

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -23,14 +23,15 @@
      ~@body
      (gather-stats @*covered*)))
 
-(defn cover [idx]
+(defn cover
   "Mark the given file and line in as having been covered."
-  (if (contains? @*covered* idx)
-    (swap! *covered* #(-> %
-                          (assoc-in [idx :covered] true)
-                          (update-in [idx :hits] (fnil inc 1))))
-    (log/warn (str "Couldn't track coverage for form with index " idx
-                   " covered has " (count @*covered*) "."))))
+  [idx]
+  (let [covered (swap! *covered* #(if-let [{:keys [hits] :as data} (nth % idx nil)]
+                                    (assoc % idx (assoc data :covered true :hits (inc (or hits 0))))
+                                    %))]
+    (when-not (nth covered idx nil)
+      (log/warn (str "Couldn't track coverage for form with index " idx
+                     " covered has " (count covered) ".")))))
 
 (defmacro capture
   "Eval the given form and record that the given line on the given


### PR DESCRIPTION
Hi, currently running Cloverage on the [cider-nrepl](https://github.com/clojure-emacs/cider-nrepl) test suite in Travis can take upwards of 5 minutes, which seems to be causing the Travis job to often time out and fail.

This patch makes a few changes to the `cover` fn:

* Replace the `assoc-in` and `update-in` operations on the vector with a single `assoc`. This makes quite a difference in very hot functions that are covered.
* Don't deref the `*covered*` atom before/after calling `swap!` on it - we have access to the old value within the fn passed to `swap!`, and access to the new value from the return value of `swap!` - presumably `cover` is being called from multiple threads concurrently, so this is actually a check-then-act race.
* Move docstring to correct position before arg vector.

This change results in the time to run Cloverage on `cider-nrepl` decreasing from ~3 minutes to ~1 minute locally:

Before:
![screenshot 2015-12-17 14 15 34](https://cloud.githubusercontent.com/assets/1759291/11871644/c7e217c6-a4c8-11e5-8393-8eadc3b001f6.png)

After:
![screenshot 2015-12-17 14 15 57](https://cloud.githubusercontent.com/assets/1759291/11871656/d0c60b2c-a4c8-11e5-8ff3-f5a396a1f02d.png)
