### PR TITLE
Support for cljc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pom.xml
 */.lein-repl-history
 */out/
 */.nrepl-port
+.idea/
+cloverage.iml

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -1,4 +1,4 @@
-(defproject cloverage "1.0.7-SNAPSHOT"
+(defproject cloverage "1.0.8-SNAPSHOT"
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/lshift/cloverage"
   :scm {:name "git"

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -17,8 +17,8 @@
     :scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
     :deploy-via :clojars
   }
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.clojure/tools.reader "0.9.2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/tools.reader "1.0.0-alpha2"]
                  [org.clojure/tools.cli "0.3.1"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/data.xml "0.0.8"]

--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -402,7 +402,8 @@
       (let [src (form-reader lib)]
         (loop [instrumented-forms nil]
           (if-let [form (binding [*read-eval* false]
-                          (r/read src false nil))]
+                                 (r/read {:eof nil
+                                          :read-cond :allow} src))]
             (let [line-hint (:line (meta form))
                   form      (if (and (iobj? form)
                                      (nil? (:file (meta form))))

--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -403,6 +403,7 @@
         (loop [instrumented-forms nil]
           (if-let [form (binding [*read-eval* false]
                                  (r/read {:eof nil
+                                          :features #{:clj}
                                           :read-cond :allow} src))]
             (let [line-hint (:line (meta form))
                   form      (if (and (iobj? form)

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -38,4 +38,5 @@
     (first (drop-while #(not= 'ns (first %))
                        (take-while (comp not nil?)
                                    (repeatedly #(r/read {:eof nil
+                                                         :features #{:clj}
                                                          :read-cond :allow} src)))))))

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -6,23 +6,25 @@
 
 (defn resource-path
   "Given a symbol representing a lib, return a classpath-relative path.  Borrowed from core.clj."
-  [lib]
-  (str (.. (name lib)
-           (replace \- \_)
-           (replace \. \/))
-       ".clj"))
+  ([lib] (resource-path lib "clj"))
+  ([lib extension]
+    (str (.. (name lib)
+             (replace \- \_)
+             (replace \. \/))
+         extension)))
 
 (defn resource-reader [resource]
-  (if-let [resource (.getResourceAsStream
-                      (clojure.lang.RT/baseLoader)
-                      resource)]
-    resource
-    (throw (IllegalArgumentException. (str "Cannot find resource " resource)))))
+  (when-let [resource (.getResourceAsStream
+                        (clojure.lang.RT/baseLoader)
+                        resource)]
+            resource))
 
 (defn form-reader [ns-symbol]
   (rt/indexing-push-back-reader
-   (rt/input-stream-push-back-reader
-    (resource-reader (resource-path ns-symbol)))))
+    (rt/input-stream-push-back-reader
+      (or (resource-reader (resource-path ns-symbol ".clj"))
+          (resource-reader (resource-path ns-symbol ".cljc"))
+          (throw (IllegalArgumentException. (str "Cannot find resource " ns-symbol " (.clj or .cljc)")))))))
 
 (defn forms [ns-symbol]
   (let [src (form-reader ns-symbol)]
@@ -35,4 +37,5 @@
   (let [src (form-reader ns-symbol)]
     (first (drop-while #(not= 'ns (first %))
                        (take-while (comp not nil?)
-                                   (repeatedly #(r/read src false nil)))))))
+                                   (repeatedly #(r/read {:eof nil
+                                                         :read-cond :allow} src)))))))


### PR DESCRIPTION
Enable Cloverage to read Clojure files with a cljc extension ie. shared code between front end and backend. Clojure and tools.reader versions are updated. Resource path starts to use memoize to enhance performance.