### PR TITLE
Add support for files with cljc extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ pom.xml
 */.lein-repl-history
 */out/
 */.nrepl-port
+.idea/
+cloverage.iml

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -1,4 +1,4 @@
-(defproject cloverage "1.0.7-SNAPSHOT"
+(defproject cloverage "1.0.8-SNAPSHOT"
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/lshift/cloverage"
   :scm {:name "git"

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -1,4 +1,4 @@
-(defproject cloverage "1.0.8-SNAPSHOT"
+(defproject cloverage "1.0.7-SNAPSHOT"
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/lshift/cloverage"
   :scm {:name "git"

--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -402,7 +402,10 @@
       (let [src (form-reader lib)]
         (loop [instrumented-forms nil]
           (if-let [form (binding [*read-eval* false]
-                          (r/read src false nil))]
+                          (r/read {:eof nil
+                                   :features #{:clj}
+                                   :read-cond :allow}
+                                  src))]
             (let [line-hint (:line (meta form))
                   form      (if (and (iobj? form)
                                      (nil? (:file (meta form))))


### PR DESCRIPTION
Often times in a project there is some Clojure code that is shared with front end and back end. Such code can be in a file with cljc extension. Add support for this kind of files. If a namespace is not found with clj extension, code will try cljc. Only thereafter an exception is thrown.