### PR TITLE
add lcov format report

### DIFF
--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -1,4 +1,4 @@
-(defproject cloverage "1.0.7-SNAPSHOT"
+(defproject cloverage "1.0.8-SNAPSHOT"
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/lshift/cloverage"
   :scm {:name "git"

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -84,6 +84,8 @@
         "Produce an HTML report." :default true]
        ["--[no-]emma-xml"
         "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
+       ["--[no-]lcov"
+        "Produce a lcov/gcov report." :default false]
        ["--[no-]codecov"
         "Generate a JSON report for Codecov.io" :default false]
        ["--[no-]coveralls"
@@ -148,6 +150,7 @@
         html?         (:html opts)
         raw?          (:raw opts)
         emma-xml?     (:emma-xml opts)
+        lcov?         (:lcov opts)
         codecov?      (:codecov opts)
         coveralls?    (:coveralls opts)
         summary?      (:summary opts)
@@ -201,6 +204,7 @@
                            (when html? (html-report output stats)
                              (html-summary output stats))
                            (when emma-xml? (emma-xml-report output stats))
+                           (when lcov? (lcov-report output stats))
                            (when raw? (raw-report output stats @*covered*))
                            (when codecov? (codecov-report output stats))
                            (when coveralls? (coveralls-report output stats))

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -138,6 +138,25 @@
           xml/sexp-as-element (xml/emit wr)))
     nil))
 
+(defn lcov-report
+  "Write LCOV report to '${out-dir}/lcov.info'."
+  [out-dir forms]
+  (let [file (File. out-dir "lcov.info")]
+    (.mkdirs (.getParentFile file))
+    (with-out-writer file
+      (doseq [[rel-file file-forms] (group-by :file forms)]
+        (let [lines (line-stats file-forms)
+              instrumented (filter :instrumented? lines)]
+          (println "TN:")
+          (printf "SF:%s%n" rel-file)
+          (doseq [line instrumented]
+            (printf "DA:%d,%d%n" (:line line) (:hit line)))
+          (printf "LF:%d%n" (count instrumented))
+          (printf "LH:%d%n" (count (filter (fn [line] (> (:hit line) 0)) lines)))
+          (println "end_of_record"))))
+    nil))
+
+
 (defn- html-spaces [s]
   (.replace s " " "&nbsp;"))
 

--- a/cloverage/test/cloverage/test_coverage.clj
+++ b/cloverage/test/cloverage/test_coverage.clj
@@ -225,7 +225,7 @@
     (is (=
          (cloverage.coverage/-main
           "-o" "out"
-          "--text" "--html" "--raw" "--emma-xml" "--coveralls"
+          "--text" "--html" "--raw" "--emma-xml" "--lcov" "--coveralls"
           "-x" "cloverage.sample"
           "cloverage.sample")
          0))))


### PR DESCRIPTION
i was looking for a way to display clojure coverage information in emacs and since i've been using coverlay which is based on the (plaintext) lcov format i added a reporter.

will write line coverage to out/lcov.info if enabled.
currently does not support (optional) branch & function coverage metrics