### PR TITLE
Don't assume file extensions are always `clj` in coverage reports

### DIFF
--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -1,28 +1,32 @@
 (ns cloverage.source
-  (:import java.lang.IllegalArgumentException)
-  (:require [clojure.tools.reader.reader-types :as rt]
-            [clojure.tools.reader :as r])
-  (:use    [cloverage.debug]))
+  (:require [clojure.tools.reader :as r]
+            [clojure.tools.reader.reader-types :as rt]
+            [clojure.java.io :as io]))
+
+(defn- get-loader []
+  (clojure.lang.RT/baseLoader))
+
+(defn- resource-exists? [path]
+  (not (nil? (io/resource path (get-loader)))))
 
 (defn resource-path
   "Given a symbol representing a lib, return a classpath-relative path.  Borrowed from core.clj."
   [lib]
-  (str (.. (name lib)
-           (replace \- \_)
-           (replace \. \/))
-       ".clj"))
+  (let [base (.. (name lib)
+                 (replace \- \_)
+                 (replace \. \/))]
+    (->> ["clj" "cljc"]
+         (map #(str base "." %))
+         (filter resource-exists?)
+         first)))
 
 (defn resource-reader [resource]
-  (if-let [resource (.getResourceAsStream
-                      (clojure.lang.RT/baseLoader)
-                      resource)]
+  (if-let [resource (and resource
+                         (.getResourceAsStream
+                          (get-loader)
+                          resource))]
     resource
-    ;; try cljc if clj not found
-    (if-let [resource (.getResourceAsStream
-                        (clojure.lang.RT/baseLoader)
-                        (str resource "c"))]
-      resource
-      (throw (IllegalArgumentException. (str "Cannot find resource " resource))))))
+    (throw (IllegalArgumentException. (str "Cannot find resource " resource)))))
 
 (defn form-reader [ns-symbol]
   (rt/indexing-push-back-reader


### PR DESCRIPTION
The current version always emits file paths as a clj file in reports even if they are cljc files.