### PR TITLE
Fix a bug related to multibyte chars

### DIFF
--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -25,12 +25,12 @@
                          (.getResourceAsStream
                           (get-loader)
                           resource))]
-    resource
+    (java.io.InputStreamReader. resource) ; We assume the default charset is set correctly
     (throw (IllegalArgumentException. (str "Cannot find resource " resource)))))
 
 (defn form-reader [ns-symbol]
   (rt/indexing-push-back-reader
-   (rt/input-stream-push-back-reader
+   (java.io.PushbackReader.
     (resource-reader (resource-path ns-symbol)))))
 
 (defn forms [ns-symbol]

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -1,28 +1,32 @@
 (ns cloverage.source
-  (:import java.lang.IllegalArgumentException)
-  (:require [clojure.tools.reader.reader-types :as rt]
-            [clojure.tools.reader :as r])
-  (:use    [cloverage.debug]))
+  (:require [clojure.tools.reader :as r]
+            [clojure.tools.reader.reader-types :as rt]
+            [clojure.java.io :as io]))
+
+(defn- get-loader []
+  (clojure.lang.RT/baseLoader))
+
+(defn- resource-exists? [path]
+  (not (nil? (io/resource path (get-loader)))))
 
 (defn resource-path
   "Given a symbol representing a lib, return a classpath-relative path.  Borrowed from core.clj."
   [lib]
-  (str (.. (name lib)
-           (replace \- \_)
-           (replace \. \/))
-       ".clj"))
+  (let [base (.. (name lib)
+                 (replace \- \_)
+                 (replace \. \/))]
+    (->> ["clj" "cljc"]
+         (map #(str base "." %))
+         (filter resource-exists?)
+         first)))
 
 (defn resource-reader [resource]
-  (if-let [resource (.getResourceAsStream
-                      (clojure.lang.RT/baseLoader)
-                      resource)]
+  (if-let [resource (and resource
+                         (.getResourceAsStream
+                          (get-loader)
+                          resource))]
     resource
-    ;; try cljc if clj not found
-    (if-let [resource (.getResourceAsStream
-                        (clojure.lang.RT/baseLoader)
-                        (str resource "c"))]
-      resource
-      (throw (IllegalArgumentException. (str "Cannot find resource " resource))))))
+    (throw (IllegalArgumentException. (str "Cannot find resource " resource)))))
 
 (defn form-reader [ns-symbol]
   (rt/indexing-push-back-reader

--- a/cloverage/test/cloverage/sample/multibyte_sample.clj
+++ b/cloverage/test/cloverage/sample/multibyte_sample.clj
@@ -1,0 +1,3 @@
+(ns cloverage.sample.multibyte-sample)
+
+(def a "あ")

--- a/cloverage/test/cloverage/source_test.clj
+++ b/cloverage/test/cloverage/source_test.clj
@@ -1,0 +1,10 @@
+(ns cloverage.source-test
+  (:require [cloverage.source :as sut]
+            [clojure.test :as t]))
+
+(t/deftest multibyte-test
+  "Regression test for a bug where the form reader fails to read files
+  containing multibyte chars."
+  (t/is (= (sut/forms 'cloverage.sample.multibyte-sample)
+           '((ns cloverage.sample.multibyte-sample)
+             (def a "あ")))))

--- a/cloverage/test/cloverage/test_coverage.clj
+++ b/cloverage/test/cloverage/test_coverage.clj
@@ -203,7 +203,8 @@
   (testing "all namespaces in a directory get returned when only path is provided"
     (is (compare-colls (find-nses "test/cloverage/sample" [])
                        ["cloverage.sample.dummy-sample"
-                        "cloverage.sample.read-eval-sample"])))
+                        "cloverage.sample.read-eval-sample"
+                        "cloverage.sample.multibyte-sample"])))
   (testing "only matching namespaces (from classpath) are returned when only
            regex patterns are provided:"
     (testing "single pattern case"


### PR DESCRIPTION
I've fixed a bug where the form reader fails to read files containing multi-byte chars because `clojure.tools.reader.reader_types.InputStreamReader` doesn't take charset into account.
This bug seems to be introduced by #79. 


Example to reproduce the tools.reader's problem:
```clj
;; NG: clojure.tools.reader.reader_types.InputStreamReader
(->> (java.io.ByteArrayInputStream. (.getBytes "あ"))
     rt/input-stream-reader
     rt/indexing-push-back-reader
     rt/read-char) ; => \ã

;; OK java.io.InputStreamReader
(->> (java.io.ByteArrayInputStream. (.getBytes "あ"))
     java.io.InputStreamReader.
     java.io.PushbackReader.
     rt/indexing-push-back-reader
     rt/read-char) ; => \あ
```

**NOTE:** This PR depends on #107.