### PR TITLE
add lcov format report

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -85,6 +85,8 @@
         "Produce an HTML report." :default true]
        ["--[no-]emma-xml"
         "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
+       ["--[no-]lcov"
+        "Produce a lcov/gcov report." :default false]
        ["--[no-]codecov"
         "Generate a JSON report for Codecov.io" :default false]
        ["--[no-]coveralls"
@@ -149,6 +151,7 @@
         html?         (:html opts)
         raw?          (:raw opts)
         emma-xml?     (:emma-xml opts)
+        lcov?         (:lcov opts)
         codecov?      (:codecov opts)
         coveralls?    (:coveralls opts)
         summary?      (:summary opts)
@@ -202,6 +205,7 @@
                            (when html? (html-report output stats)
                              (html-summary output stats))
                            (when emma-xml? (emma-xml-report output stats))
+                           (when lcov? (lcov-report output stats))
                            (when raw? (raw-report output stats @*covered*))
                            (when codecov? (codecov-report output stats))
                            (when coveralls? (coveralls-report output stats))

--- a/cloverage/test/cloverage/sample/raw-data.clj
+++ b/cloverage/test/cloverage/sample/raw-data.clj
@@ -1,0 +1,69 @@
+{0
+ {:form
+  (ns
+   cloverage.sample.dummy-sample
+   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+  :full-form
+  (ns
+   cloverage.sample.dummy-sample
+   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+  :tracked true,
+  :line 1,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :covered true,
+  :hits 1},
+ 1
+ {:form
+  (def
+   dummy-function
+   (clojure.core/fn
+    ([& args]
+     (cloverage.instrument/wrapm
+      cloverage.coverage/track-coverage
+      5
+      (println "Hello, World!"))))),
+  :full-form
+  (def
+   dummy-function
+   (clojure.core/fn
+    ([& args]
+     (cloverage.instrument/wrapm
+      cloverage.coverage/track-coverage
+      5
+      (println "Hello, World!"))))),
+  :tracked true,
+  :line 5,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :covered true,
+  :hits 1},
+ 2
+ {:form (println "Hello, World!"),
+  :full-form
+  ((cloverage.instrument/wrapm
+    cloverage.coverage/track-coverage
+    7
+    println)
+   (cloverage.instrument/wrapm
+    cloverage.coverage/track-coverage
+    7
+    "Hello, World!")),
+  :tracked true,
+  :line 7,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"},
+ 3
+ {:form println,
+  :full-form println,
+  :tracked true,
+  :line 7,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"},
+ 4
+ {:form "Hello, World!",
+  :full-form "Hello, World!",
+  :tracked true,
+  :line 7,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"}}

--- a/cloverage/test/cloverage/sample/raw-stats.clj
+++ b/cloverage/test/cloverage/sample/raw-stats.clj
@@ -1,0 +1,86 @@
+({:text "(ns cloverage.sample.dummy-sample",
+  :line 1,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :form
+  (ns
+   cloverage.sample.dummy-sample
+   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+  :full-form
+  (ns
+   cloverage.sample.dummy-sample
+   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+  :tracked true,
+  :covered true,
+  :hits 1}
+ {:text "  \"This namespace is necessary for redundancy.",
+  :line 2,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"}
+ {:text
+  "  It allows us to check whether regexs in combination with path parameters work.\")",
+  :line 3,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"}
+ {:text "",
+  :line 4,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"}
+ {:text "(defn dummy-function",
+  :line 5,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :form
+  (def
+   dummy-function
+   (clojure.core/fn
+    ([& args]
+     (cloverage.instrument/wrapm
+      cloverage.coverage/track-coverage
+      5
+      (println "Hello, World!"))))),
+  :full-form
+  (def
+   dummy-function
+   (clojure.core/fn
+    ([& args]
+     (cloverage.instrument/wrapm
+      cloverage.coverage/track-coverage
+      5
+      (println "Hello, World!"))))),
+  :tracked true,
+  :covered true,
+  :hits 1}
+ {:text "  [& args]",
+  :line 6,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj"}
+ {:text "  (println \"Hello, World!\"))",
+  :line 7,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :form (println "Hello, World!"),
+  :full-form
+  ((cloverage.instrument/wrapm
+    cloverage.coverage/track-coverage
+    7
+    println)
+   (cloverage.instrument/wrapm
+    cloverage.coverage/track-coverage
+    7
+    "Hello, World!")),
+  :tracked true}
+ {:text "  (println \"Hello, World!\"))",
+  :line 7,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :form println,
+  :full-form println,
+  :tracked true}
+ {:text "  (println \"Hello, World!\"))",
+  :line 7,
+  :lib cloverage.sample.dummy-sample,
+  :file "cloverage/sample/dummy_sample.clj",
+  :form "Hello, World!",
+  :full-form "Hello, World!",
+  :tracked true})

--- a/cloverage/test/cloverage/test_coverage.clj
+++ b/cloverage/test/cloverage/test_coverage.clj
@@ -226,7 +226,7 @@
     (is (=
          (cloverage.coverage/-main
           "-o" "out"
-          "--text" "--html" "--raw" "--emma-xml" "--coveralls"
+          "--text" "--html" "--raw" "--emma-xml" "--lcov" "--coveralls"
           "-x" "cloverage.sample"
           "cloverage.sample")
          0))))

--- a/cloverage/test/cloverage/test_report.clj
+++ b/cloverage/test/cloverage/test_report.clj
@@ -1,7 +1,30 @@
 (ns cloverage.test-report
   (:import java.io.File)
   (:use clojure.test
-        cloverage.report))
+        cloverage.report)
+  (:require [clojure.tools.reader :as r]
+            [clojure.java.io :as io]))
+
+(defn- parse-readable
+  "parse in all forms from reader"
+  [reader]
+  (with-open [pb-reader (java.io.PushbackReader. reader)]
+    (binding [*read-eval* false]
+      (let [exp-reader (repeatedly #(read pb-reader false nil))]
+        (doall (take-while identity exp-reader))))))
+
+(defn- get-resource-as-stream
+  "open resource from classpath as stream"
+  [resource]
+  (.getResourceAsStream (clojure.lang.RT/baseLoader) resource))
+
+(defn- parse-resource
+  "opens the resource-name and returns the parsed forms"
+  [resource-name]
+  (parse-readable (io/reader (get-resource-as-stream resource-name))))
+
+(def test-raw-forms (vals (first (parse-resource "cloverage/sample/raw-data.clj"))))
+(def test-gathered-forms (first (parse-resource "cloverage/sample/raw-stats.clj")))
 
 (deftest test-relative-path
   (is (= "child/" (relative-path (File. "parent/child/") (File. "parent/"))))
@@ -17,3 +40,25 @@
 
 (deftest total-stats-zero
   (is (= {:percent-lines-covered 0.0, :percent-forms-covered 0.0} (total-stats {}))))
+
+
+
+(deftest gather-starts-works-on-empty-forms
+  (is (= [] (gather-stats []))))
+
+(deftest gather-starts-converts-file-forms
+  (with-redefs [cloverage.report/postprocess-file (fn [lib file forms] {:lib lib :file file})]
+    (is (= '([:lib "lib"] [:file "file"]) (gather-stats [{:lib "lib" :file "file" :line 1}])))))
+
+(deftest gather-starts-converts-raw-forms
+  (with-redefs [cloverage.source/resource-reader (fn [filename] (io/reader (get-resource-as-stream filename)))]
+    (is (= test-gathered-forms (gather-stats test-raw-forms)))))
+
+(deftest lcov-report-writes-empty-report-with-no-forms
+  (let [report (with-out-str (#'cloverage.report/write-lcov-report []))]
+    (is (= "" report))))
+
+(deftest lcov-report-writes-report-with-forms
+  (let [test-forms test-gathered-forms
+        report (with-out-str (#'cloverage.report/write-lcov-report test-forms))]
+    (is (= "TN:\nSF:cloverage/sample/dummy_sample.clj\nDA:1,1\nDA:5,1\nDA:7,0\nLF:3\nLH:2\nend_of_record\n" report))))


### PR DESCRIPTION
- adds LCOV format used by many basic tools (eg coverlay)
- to enable report testing, added output of raw data and stats for sample.clj
- some basic testing of output conversion functions