### PR TITLE
Remove statement about requiring Clojure 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cloverage
 =========
 
-Simple clojure coverage tool. Currently requires clojure 1.4.
+Simple clojure coverage tool.
 
 [![Build Status](https://secure.travis-ci.org/lshift/cloverage.png?branch=master)](http://travis-ci.org/lshift/cloverage)
 


### PR DESCRIPTION
1.4 is ancient. Nobody uses it anymore. This has confused several people into thinking you needed exactly that version, as opposed to at least that version.